### PR TITLE
Update app.kv

### DIFF
--- a/launcher/app.kv
+++ b/launcher/app.kv
@@ -152,4 +152,4 @@ GridLayout:
 <LogLabel@Label>:
     color: rgba("#222222FF")
     pos_hint: {'x': 0}
-    width: self.texture_size[0]
+    size: self.texture_size


### PR DESCRIPTION

![Screenshot_2024-01-10-18-46-46-039_org kivy launcher](https://github.com/kivy/kivy-launcher/assets/44273579/25b8f749-94b3-471d-bd93-179934ee4969)
In my android 12, the text of the logs overlapped without this correction